### PR TITLE
Added 'MinGW x64 support' with latest GCC 8.1.0 on Windows

### DIFF
--- a/modules/std/fiber/fcontext.monkey2
+++ b/modules/std/fiber/fcontext.monkey2
@@ -10,9 +10,15 @@ Namespace std.fiber
 
 #If __TARGET__="windows"
 
-	#import "native/asm/make_i386_ms_pe_gas.asm"
-	#import "native/asm/jump_i386_ms_pe_gas.asm"
-	#import "native/asm/ontop_i386_ms_pe_gas.asm"
+	#if __ARCH__="x86"
+		#import "native/asm/make_i386_ms_pe_gas.asm"
+		#import "native/asm/jump_i386_ms_pe_gas.asm"
+		#import "native/asm/ontop_i386_ms_pe_gas.asm"
+	#elseif __ARCH__="x64"
+		#import "native/asm/make_x86_64_ms_pe_gas.asm"
+		#import "native/asm/jump_x86_64_ms_pe_gas.asm"
+		#import "native/asm/ontop_x86_64_ms_pe_gas.asm"
+	#endif
 
 #Else If __TARGET__="macos"
 

--- a/src/mx2cc/mx2cc.monkey2
+++ b/src/mx2cc/mx2cc.monkey2
@@ -516,7 +516,7 @@ Function ParseOpts:String[]( opts:BuildOpts,args:String[] )
 		Endif
 	
 		If opts.arch="x64" And opts.toolchain<>"msvc"
-			Fail( "x64 builds for windows currently only supported for msvc" )
+			'Fail( "x64 builds for windows currently only supported for msvc" )
 		Endif
 		
 	Case "macos","linux"


### PR DESCRIPTION
Needs : 
- Update 'mx2cc'
- Rebuild modules
- Somes changes on "env_windows.txt" :
        - MX2_USE_MSVC=0
        - MX2_LD_OPTS_WINDOWS=-s -static -m64
        - MX2_CC_OPTS_WINDOWS=-std=gnu99 -D_WIN32_WINNT=0x0603 -m64 -Wa,-mbig-obj
        - MX2_CPP_OPTS_WINDOWS=-std=c++11 -D_WIN32_WINNT=0x0603 -m64 -Wa,-mbig-obj

MinGW-x64 : https://sourceforge.net/projects/mingw-w64/files/Toolchains%20targetting%20Win64/Personal%20Builds/mingw-builds/8.1.0/threads-posix/seh/x86_64-8.1.0-release-posix-seh-rt_v6-rev0.7z